### PR TITLE
Refactor book management API to use claims for userId

### DIFF
--- a/Backend/Controllers/BookController.cs
+++ b/Backend/Controllers/BookController.cs
@@ -27,30 +27,34 @@ public class BookController(IBookService bookService) : ControllerBase
         return Ok(book);
     }
 
-    [HttpPost("user/{userId}/book/add")]
-    public async Task<IActionResult> AddBook(int userId, [FromBody] BookDetailsDTO book)
+    [HttpPost("add")]
+    public async Task<IActionResult> AddBook([FromBody] BookDetailsDTO book)
     {
+        var userId = int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
         await _bookService.AddBookAsync(userId, book);
         return Ok(new Response { Message = "Book added successfully", Success = true });
     }
 
-    [HttpPatch("user/{userId}/book/update")]
-    public async Task<IActionResult> UpdateBook(int userId, [FromBody] BookDetailsDTO book)
+    [HttpPatch("update")]
+    public async Task<IActionResult> UpdateBook([FromBody] BookDetailsDTO book)
     {
+        var userId = int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
         await _bookService.UpdateBookAsync(userId, book);
         return Ok(new Response { Message = "Book updated successfully", Success = true });
     }
 
-    [HttpDelete("user/{userId}/book/delete/{bookId}")]
-    public async Task<IActionResult> DeleteBook(int userId, int bookId)
+    [HttpDelete("delete/{bookId}")]
+    public async Task<IActionResult> DeleteBook(int bookId)
     {
+        var userId = int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
         await _bookService.DeleteBookAsync(userId, bookId);
         return Ok(new Response { Message = "Book deleted successfully", Success = true });
     }
 
-    [HttpDelete("user/{userId}/book/delete/all")]
-    public async Task<IActionResult> DeleteAllBooks(int userId)
+    [HttpDelete("delete/all")]
+    public async Task<IActionResult> DeleteAllBooks()
     {
+        var userId = int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
         await _bookService.DeleteAllBooksAsync(userId);
         return Ok(new Response { Message = "All books deleted successfully", Success = true });
     }

--- a/Backend/Controllers/UserController.cs
+++ b/Backend/Controllers/UserController.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using Backend.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -25,9 +26,10 @@ public class UserController(IUserService userService) : ControllerBase
         return Ok(users);
     }
 
-    [HttpGet("{userId}/username")]
-    public async Task<IActionResult> GetUsernameById(int userId)
+    [HttpGet("username")]
+    public async Task<IActionResult> GetUsernameById()
     {
+        var userId = int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
         var user = await _userService.GetByIdAsync(userId);
         if (user == null)
         {

--- a/frontend/src/components/Form/AddBookForm.tsx
+++ b/frontend/src/components/Form/AddBookForm.tsx
@@ -84,7 +84,7 @@ const AddBookForm: React.FC = () => {
       console.error("User ID is not available");
       return;
     }
-    const response = await bookService.addBook(userId, bookData);
+    const response = await bookService.addBook(bookData);
     if (response.success) {
       alert("Book added successfully");
     }

--- a/frontend/src/pages/BookDetail.tsx
+++ b/frontend/src/pages/BookDetail.tsx
@@ -74,7 +74,7 @@ const BookDetail: React.FC = () => {
 
   const handleDelete = () => {
     if (book && userId) {
-      bookService.deleteBook(userId, book.id).then((response) => {
+      bookService.deleteBook(book.id).then((response) => {
         if (response.success) {
           setBook(null);
           navigate(`/${userId}/books`);
@@ -100,7 +100,7 @@ const BookDetail: React.FC = () => {
         console.error("User ID is not defined");
         return;
       }
-      bookService.updateBook(userId, editedBook).then((response) => {
+      bookService.updateBook(editedBook).then((response) => {
         if (response.success) {
           editedBook.dateRead = editedBook.dateRead
             ? editedBook.dateRead.split("T")[0]

--- a/frontend/src/services/bookService.ts
+++ b/frontend/src/services/bookService.ts
@@ -19,19 +19,19 @@ const getBook = async (userId: string ,bookId: number) => {
   return response.data;
 };
 
-const addBook = async (userId: string, book: any) => {
-  const response = await apiClient.post(`/Book/user/${userId}/book/add`, book);
+const addBook = async (book: any) => {
+  const response = await apiClient.post(`/Book/add`, book);
   localStorage.removeItem("userBooks");
   return response.data;
 };
 
-const updateBook = async (userId: string, book: any) => {
-  const response = await apiClient.patch(`/Book/user/${userId}/book/update`, book);
+const updateBook = async (book: any) => {
+  const response = await apiClient.patch(`/Book/update`, book);
   return response.data;
 };
 
-const deleteBook = async (userId: string, bookId: number) => {
-  const response = await apiClient.delete(`/Book/user/${userId}/book/delete/${bookId}`);
+const deleteBook = async (bookId: number) => {
+  const response = await apiClient.delete(`/Book/delete/${bookId}`);
   const userBooks = localStorage.getItem("userBooks");
   if (userBooks && userBooks !== "undefined") {
     const books = JSON.parse(userBooks);
@@ -41,8 +41,8 @@ const deleteBook = async (userId: string, bookId: number) => {
   return response.data;
 };
 
-const deleteAllBooks = async (userId: string) => {
-  const response = await apiClient.delete(`/Book/user/${userId}/book/delete/all`);
+const deleteAllBooks = async () => {
+  const response = await apiClient.delete(`/Book/delete/all`);
   localStorage.removeItem("userBooks");
   return response.data;
 }

--- a/frontend/src/services/userService.ts
+++ b/frontend/src/services/userService.ts
@@ -20,9 +20,9 @@ const getAllUsers = async (userId: string) => {
     }
 }
 
-const getUsernameById = async (userId: string) => {
+const getUsernameById = async () => {
     try {
-        const response = await apiClient.get(`/User/${userId}/username`);
+        const response = await apiClient.get(`/User/username`);
         return response.data.username;
     }
     catch (error) {


### PR DESCRIPTION
Remove userId from routes in the book management API and UserController, retrieving it from claims instead. This simplifies the API and enhances security by not exposing userId in the route.